### PR TITLE
README.rst: Fix rendering on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 bade
 ####
 
-.. image:: docs/source/_static/bade.png
+.. image:: https://raw.githubusercontent.com/bmcorser/bade/master/docs/source/_static/bade.png
            :alt: bade
            :width: 400px
 


### PR DESCRIPTION
You can't use a local file for an image on PyPI; it has to be a URL I think.

Merge this and then do `python setup.py register` to update the PyPI description.